### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# posgresql-lo-stream
+# postgresql-lo-stream
 
 This library provides some convenience functions for working with [Large Objects](https://www.postgresql.org/docs/current/largeobjects.html) in PostgreSQL. This is built on top of [postgresql-simple](https://hackage.haskell.org/package/postgresql-simple/docs/Database-PostgreSQL-Simple-LargeObjects.html), which provides the lower-level functions for interacting with Large Objects.


### PR DESCRIPTION
The typo fix from #1 also hasn't yet been published on hackage.